### PR TITLE
Add install script for services

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README-RU.md
+++ b/README-RU.md
@@ -1,4 +1,5 @@
 # backend-microservices-template
+
 ## Backend Microservices Template Nest.Js Typescript
 
 ## Архитектура
@@ -21,6 +22,20 @@ npm run add:service -- <имя-сервиса>
 добавит зависимость `@backend/shared` и автоматически подключит сервис
 к рабочей области.
 
+## Запуск сервисов
+
+Для установки зависимостей во всех сервисах выполните:
+
+```bash
+npm run install:services
+```
+
+Для запуска всех сервисов в режиме разработки выполните:
+
+```bash
+npm run start:services
+```
+
 ## Docker
 
 Для каждого сервиса есть `Dockerfile`. Файл `docker-compose.yml` подтягивает
@@ -36,4 +51,3 @@ docker compose up
 собирает Docker-образы, отправляет их во внешний реестр и разворачивает
 их на сервере по SSH. Перед запуском `docker compose` на сервере выполняется
 вход в реестр.
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # backend-microservices-template
+
 Backend Microservices Template Nest.Js Typescript
 
 ## Architecture
@@ -21,6 +22,20 @@ The command generates a NestJS project under `packages/<service-name>`,
 adds the `@backend/shared` package as a dependency and includes the
 service in the workspace automatically.
 
+## Development
+
+Install dependencies for all services:
+
+```bash
+npm run install:services
+```
+
+Use the following command to start all services in watch mode:
+
+```bash
+npm run start:services
+```
+
 ## Docker
 
 Each service contains a `Dockerfile`. The `docker-compose.yml` file pulls
@@ -36,4 +51,3 @@ The `Release` workflow publishes new package versions. After a successful releas
 or when triggered manually, the `Deploy` workflow builds Docker images, pushes
 them to the external registry and deploys them on the server via SSH. The server
 logs in to the registry before running `docker compose`.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
+        "concurrently": "^9.2.0",
         "semantic-release": "24.2.7",
         "semantic-release-monorepo": "8.0.2",
         "yaml": "^2.8.0"
@@ -6174,6 +6175,48 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/config-chain": {
@@ -15101,6 +15144,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -17244,7 +17300,7 @@
       }
     },
     "packages/gateway": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@backend/shared": "*",
@@ -17287,7 +17343,7 @@
       "version": "1.0.0"
     },
     "packages/users": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@backend/shared": "*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "add:service": "node tools/add-service.js",
-    "release": "node tools/run-release.js"
+    "release": "node tools/run-release.js",
+    "start:services": "concurrently -k \"npm run start:dev -w packages/gateway\" \"npm run start:dev -w packages/users\"",
+    "install:services": "npm install --workspaces"
   },
   "workspaces": [
     "packages/*"
@@ -17,6 +19,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
+    "concurrently": "^9.2.0",
     "semantic-release": "24.2.7",
     "semantic-release-monorepo": "8.0.2",
     "yaml": "^2.8.0"


### PR DESCRIPTION
## Summary
- add `install:services` script to install dependencies in every workspace
- document how to install dependencies before starting services
- format README files with Prettier

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687cb9d0b1ec832aa026c27f324624be