### PR TITLE
Fix path resolution for shared library

### DIFF
--- a/packages/gateway/src/app.controller.spec.ts
+++ b/packages/gateway/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return SharedType object', () => {
+      expect(appController.getHello()).toEqual({ id: 1, name: 'Hello World!' });
     });
   });
 });

--- a/packages/gateway/src/app.controller.ts
+++ b/packages/gateway/src/app.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { SharedType } from '@backend/shared';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
+  getHello(): SharedType {
     return this.appService.getHello();
   }
 }

--- a/packages/gateway/test/app.e2e-spec.ts
+++ b/packages/gateway/test/app.e2e-spec.ts
@@ -20,6 +20,6 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect({ id: 1, name: 'Hello World!' });
   });
 });

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -10,6 +10,9 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@backend/shared": ["../shared/src"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepare": "npm run build"
   }
 }

--- a/packages/users/src/app.controller.spec.ts
+++ b/packages/users/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return SharedType object', () => {
+      expect(appController.getHello()).toEqual({ id: 1, name: 'Hello World!' });
     });
   });
 });

--- a/packages/users/src/app.controller.ts
+++ b/packages/users/src/app.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { SharedType } from '@backend/shared';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
+  getHello(): SharedType {
     return this.appService.getHello();
   }
 }

--- a/packages/users/test/app.e2e-spec.ts
+++ b/packages/users/test/app.e2e-spec.ts
@@ -20,6 +20,6 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect({ id: 1, name: 'Hello World!' });
   });
 });

--- a/packages/users/tsconfig.json
+++ b/packages/users/tsconfig.json
@@ -10,6 +10,9 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@backend/shared": ["../shared/src"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary
- add tsconfig path alias for `@backend/shared` in services
- keep build and tests passing

## Testing
- `npm run build -w packages/users`
- `npm run build -w packages/gateway`
- `npm test -w packages/users`
- `npm test -w packages/gateway`


------
https://chatgpt.com/codex/tasks/task_e_687cf1e9ec94832aaa41b285e97cd5e7